### PR TITLE
(Feat) Add endpoint for querying links using teamId

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -19,7 +19,7 @@ const controller = Botkit.slackbot({
 
 controller.setupWebserver(process.env.PORT, (err, webserver) => {
   controller.createWebhookEndpoints(controller.webserver);
-  controller.webserver.use(function(req, res, next) {
+  controller.webserver.use((req, res, next) => {
     res.header("Access-Control-Allow-Origin", "*");
     res.header("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept");
     next();
@@ -31,6 +31,14 @@ controller.setupWebserver(process.env.PORT, (err, webserver) => {
     } else {
       res.send('Success');
     }
+  });
+
+  controller.webserver.get('/links', (req, res) => {
+    const teamId = req.query.teamId;
+
+    utils.getTeamLinks(teamId, (links) => {
+      res.send(links);
+    });
   });
 });
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -8,7 +8,10 @@ const mongoose = require('mongoose');
 
 const dbUrl = process.env.MONGODB_REMOTE_URL;
 
-mongoose.connect(dbUrl);
+const connectionOptions = { server: { socketOptions: { keepAlive: 300000, connectTimeoutMS: 30000 } }, 
+                replset: { socketOptions: { keepAlive: 300000, connectTimeoutMS : 30000 } } };
+
+mongoose.connect(dbUrl, connectionOptions);
 
 const saveToDb = (linksObj, message) => {
   if (linksObj.length) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -39,4 +39,9 @@ module.exports = {
     const linksObj = linkify.find(textMessage);
     saveToDb(linksObj, message);
   },
+  getTeamLinks(teamId, callback) {
+    Link.find({ team: teamId }, (err, links) => {
+      return callback(links);
+    });
+  },
 };


### PR DESCRIPTION
#### What does this PR do?
This PR adds an endpoint for querying a user's team links.

#### How will we use it?
When a user logs in on the frontend app, we can use their team Id and send a GET to the endpoint passing the teamId as a query param:

e.g `GET http://127.0.0.1:3000/links?teamId=AGHGDUAGSU`

The endpoint will respond with the team's links.