### PR TITLE
(fix) add relevant permissions to slack app

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -13,7 +13,7 @@ const controller = Botkit.slackbot({
     clientId: process.env.APP_CLIENT_ID,
     clientSecret: process.env.APP_CLIENT_SECRET,
     redirectUri: process.env.OAUTH_REDIRECT_URI,
-    scopes: ['bot'],
+    scopes: ['bot', 'incoming-webhook', 'commands', 'channels:read'],
   }
 );
 


### PR DESCRIPTION
#### What does this PR do?
This PR adds the relevant permissions for the slack especially `channels:read` to enable us to get relevant info about a channel from the slack API e.g. a channel name.