### PR TITLE
(chore) Add procfile and node version for heroku

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: node bot.js

--- a/package.json
+++ b/package.json
@@ -32,5 +32,8 @@
     "eslint": "^3.13.1",
     "eslint-config-airbnb-base": "^11.0.1",
     "eslint-plugin-import": "^2.2.0"
+  },
+  "engines": {
+    "node": "6.9.2"
   }
 }


### PR DESCRIPTION
#### What does this PR do?
This PR adds a Heroku Procfile and an `engines` object to the `package.json` which tells Heroku to use node version `6.9.2`.